### PR TITLE
Enable pinning extension to Microsoft Edge sidebar

### DIFF
--- a/src/target/extension/manifest/index.js
+++ b/src/target/extension/manifest/index.js
@@ -168,6 +168,11 @@ module.exports = ({ vendor, production=false }, l) => {
 			}
 		} : {}),
 
+		// Enable extension to be pinned to Edge sidebar 
+		...(vendor == 'edge' ? {
+			edge_side_panel: {}
+		} : {}),
+
 		...(vendor == 'firefox' || vendor == 'opera' ? {
 			sidebar_action: {
 				default_panel: 'sidepanel.html',


### PR DESCRIPTION
Adds `edge_side_panel` config object to manifest.json to enable the extension to be pinned to the sidebar in Microsoft Edge.

This is separate from the extension [toolbar icon](https://developer.chrome.com/docs/extensions/reference/api/action). As a user, I have both the toolbar icon pinned to save bookmarks (which I also mapped to <kbd><kbd>Ctrl</kbd>+<kbd>D</kbd></kbd> to override the built-in browser bookmark shortcut) and the sidebar icon pinned to open up my bookmarks in the sidebar. It's a great workflow! Huge fan of the app, paid member, and hope this kind of contribution is welcome and follows the guidelines.

Documentation: [Develop an extension for the Microsoft Edge sidebar](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/developer-guide/sidebar)

![Screenshot 2025-03-13 220515](https://github.com/user-attachments/assets/bd4e2fbb-bd1e-4d43-8505-6c23ef6f99bf)
