### PR TITLE
feat(extension): add localized tooltip for free reminder button

### DIFF
--- a/src/co/bookmarks/edit/form/reminder.js
+++ b/src/co/bookmarks/edit/form/reminder.js
@@ -46,7 +46,7 @@ function Free() {
 
     return (
         <>
-            <Button onClick={onClick} variant='outline'>
+            <Button onClick={onClick} variant='outline' title={t.s('add') + ' ' + t.s('reminder').toLowerCase()}>
                 <Icon name='reminder' />
             </Button>
 


### PR DESCRIPTION
What: 
Adds a native tooltip to the reminder button for free tier people and it is  localized like the Pro control.

Why: 
Clarifies the button’s purpose.

Scope: 
UI-only

Verification: 
Hover over the bell in the editor; tooltip shows “Add reminder” (localized).

