### PR TITLE
fix: update Chrome Web Store URL to new domain

### DIFF
--- a/build/web.js
+++ b/build/web.js
@@ -107,7 +107,7 @@ module.exports = (env={}, args={}) =>
                         },
                         {
                             platform: 'chrome_web_store',
-                            url: 'https://chrome.google.com/webstore/detail/ldgfbffkinooeloadekpmfoklnobpien',
+                            url: 'https://chromewebstore.google.com/detail/ldgfbffkinooeloadekpmfoklnobpien',
                             id: 'ldgfbffkinooeloadekpmfoklnobpien'
                         }
                     ],


### PR DESCRIPTION
Updated deprecated chrome.google.com/webstore URL to new chromewebstore.google.com format

This is a simple fix to update the outdated Chrome Web Store URL to the new domain.