### PR TITLE
Fix system collection view fallback & Windows extension build

### DIFF
--- a/build/extension.js
+++ b/build/extension.js
@@ -7,8 +7,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const ZipPlugin = require('zip-webpack-plugin')
 
-module.exports = (env={}, args={}) => {
-    const outputPath = path.resolve(__dirname, '..', 'dist', env.vendor, env.production?'prod':'dev')
+module.exports = (env = {}, args = {}) => {
+    const outputPath = path.resolve(__dirname, '..', 'dist', env.vendor, env.production ? 'prod' : 'dev')
 
     env.filename = '[name]'
 
@@ -37,7 +37,7 @@ module.exports = (env={}, args={}) => {
 
             output: {
                 path: outputPath,
-                filename: ({ chunk: { name } }) => name=='background' ? 'background.js' : `assets/${env.filename}.js`,
+                filename: ({ chunk: { name } }) => name == 'background' ? 'background.js' : `assets/${env.filename}.js`,
                 chunkFilename: `assets/${env.filename}.js`,
                 publicPath: '',
                 globalObject: 'globalThis',
@@ -82,7 +82,7 @@ module.exports = (env={}, args={}) => {
                 ...(env.production ? [
                     new ZipPlugin({
                         path: '../../',
-                        filename: `${env.vendor}-${env.production?'prod':'dev'}.zip`,
+                        filename: `${env.vendor}-${env.production ? 'prod' : 'dev'}.zip`,
                         exclude: []
                     })
                 ] : [])
@@ -90,7 +90,7 @@ module.exports = (env={}, args={}) => {
 
             module: {
                 rules: [{
-                    test: /manifest\/index\.js$/,
+                    test: /manifest[\\/]index\.js$/,
                     use: [
                         {
                             loader: 'file-loader',

--- a/src/data/sagas/collections/items.js
+++ b/src/data/sagas/collections/items.js
@@ -54,7 +54,7 @@ export function* loadCollections({ ignore=false, onSuccess, onFail }) {
 		const state = yield select()
 		const defColls = state.collections.defaults.map((item)=>{
 			var count = 0
-			// var view = user?.config?.default_collection_view || 'list'
+			var view = item.view || user?.config?.default_collection_view || 'list'
 			
 			//count
 			if (stat.items){
@@ -65,7 +65,7 @@ export function* loadCollections({ ignore=false, onSuccess, onFail }) {
 			
 			return item
 				.set('count', count)
-				// .set('view', view)
+				.set('view', view)
 		})
 
 		yield put({


### PR DESCRIPTION
This PR addresses an issue where system collections (like "All Bookmarks") would revert to the default list view and ignore global user settings after a data refresh. 

**Changes:**
- **System Collection View Fix (`items.js`):** Updated the `defColls` mapping to properly respect locally overridden views (`item.view`) and fall back to the global `user.config.default_collection_view`. Previously, the view was being dropped during `loadCollections`, causing it to fall back to the hardcoded `list` default during normalization.

- **Windows Build Fix (`build/extension.js`):** Tweaked the `manifest/index.js` regex to support both Windows (`\`) and Unix (`/`) directory separators. This prevents Webpack from mistakenly trying to bundle the manifest script for the browser on Windows (which was causing `fs` and `path` not found crashes).

<img width="687" height="327" alt="image" src="https://github.com/user-attachments/assets/08250f8d-f89a-460f-8dd7-3b3a6dc76cde" />

### Tested On
- Windows 11
